### PR TITLE
Remove hooks dependent on cijoe-pkg-linux

### DIFF
--- a/testplans/example_02.plan
+++ b/testplans/example_02.plan
@@ -10,12 +10,9 @@ descr_long: |
 
   Now something else.
 evars: { FOO: 42 }
-hooks: [ sysinf ]
 testsuites:
   - name: example_all
   - name: example_all
     evars: { FOO: 24 }
-    hooks: [ dmesg ]
   - name: example_all
     evars: { FOO: 3 }
-    hooks_pr_tcase: [ dmesg ]


### PR DESCRIPTION
Signed-off-by: Karl Bonde Torp <karlowich@gmail.com>